### PR TITLE
Switch resize lib to pica

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,6 +44,7 @@
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",
     "mixpanel-browser": "^2.47.0",
+    "pica": "^9.0.1",
     "react-avatar-editor": "^13.0.0",
     "react-dropzone": "^14.2.3",
     "typeid-js": "^0.2.1"

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -1,15 +1,26 @@
 import AvatarEditor from 'react-avatar-editor';
+import Pica from 'pica';
 
 import { OutputSizingMode } from './types';
 
 export const getImageBlobFromEditor = (editor: AvatarEditor, type: string, sizingMode: OutputSizingMode) => {
   return new Promise<Blob>((resolve, reject) => {
-    (sizingMode === 'fixed_size' ? editor.getImageScaledToCanvas() : editor.getImage()).toBlob((blob) => {
+    const handleBlob = (blob: Blob | null) => {
       if (blob) {
         resolve(blob);
       } else {
-        reject(new Error('Error converting image to blob'));
+        reject(new Error("Error converting image to blob"));
       }
-    }, type);
+    };
+
+    if (sizingMode === 'fixed_size') {
+      const pica = new Pica();
+      pica
+        .resize(editor.getImage(), editor.getImageScaledToCanvas())
+        .then(result => result.toBlob(handleBlob, type))
+        .catch(error => reject(error));
+    } else {
+      editor.getImage().toBlob(handleBlob, type);
+    }
   });
 };


### PR DESCRIPTION
The current resize function from the `react-avatar-editor` lib is simple and the quality leaves some room for improvement. Suggest to switch to some more specific libraries, such as `pica`, to do this job