### PR TITLE
Refine export naming without tagging

### DIFF
--- a/apps/web/src/components/ImageSelectorContext.tsx
+++ b/apps/web/src/components/ImageSelectorContext.tsx
@@ -18,6 +18,7 @@ type ImageSelectorContextData = {
   outputFormat: OutputFormat;
   outputSizingMode: OutputSizingMode;
   processing: boolean;
+  downloadNameTemplate: string;
 };
 
 export const ImageSelectorContext = createContextId<ImageSelectorContextData>('image-selector-context');
@@ -29,6 +30,7 @@ export const ImageSelectorContextProvider = component$(() => {
     outputFormat: 'png',
     outputSizingMode: 'fixed_size',
     processing: false,
+    downloadNameTemplate: 'Presize.io_{timestamp}',
   });
   useContextProvider(ImageSelectorContext, context);
 

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -123,7 +123,7 @@ export default component$(() => {
                 class="input input-bordered w-full"
                 value={imageSelectorContext.downloadNameTemplate}
                 placeholder="Presize.io_{timestamp}"
-                onInput$={(e) => {
+                onChange$={(e) => {
                   const target = e.target as HTMLInputElement | null;
                   if (!target) {
                     return;

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -93,6 +93,22 @@ export default component$(() => {
               </select>
             </div>
           </div>
+          <div class="flex lg:flex-col lg:w-64 gap-2">
+            <div class="form-control w-full">
+              <label class="label">
+                <span class="label-text">Zip file name</span>
+              </label>
+              <input
+                type="text"
+                class="input input-bordered w-full"
+                value={imageSelectorContext.downloadNameTemplate}
+                placeholder="Presize.io_{timestamp}"
+                onInput$={(e) => {
+                  imageSelectorContext.downloadNameTemplate = e.target.value;
+                }}
+              />
+            </div>
+          </div>
           <div class="flex lg:flex-col lg:w-64 gap-2 pt-2">
             <button
               class="btn btn-block btn-neutral"
@@ -130,7 +146,13 @@ export default component$(() => {
                 const hiddenLink = document.createElement('a');
                 hiddenLink.style.display = 'none';
                 hiddenLink.href = zipUrl;
-                hiddenLink.download = `Presize.io_${dayjs().format('YYYY-MM-DD_HH-mm-ss')}.zip`;
+                const formattedDate = dayjs().format('YYYY-MM-DD_HH-mm-ss');
+                const template = (imageSelectorContext.downloadNameTemplate || '').trim() || 'Presize.io_{timestamp}';
+                let downloadName = template.replaceAll('{timestamp}', formattedDate);
+                if (!downloadName.toLowerCase().endsWith('.zip')) {
+                  downloadName += '.zip';
+                }
+                hiddenLink.download = downloadName;
                 document.body.appendChild(hiddenLink);
 
                 hiddenLink.click();

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -37,7 +37,12 @@ export default component$(() => {
               <select
                 class="select select-bordered"
                 onChange$={(e) => {
-                  imageSelectorContext.outputSizingMode = e.target.value as OutputSizingMode;
+                  const target = e.target as HTMLSelectElement | null;
+                  if (!target) {
+                    return;
+                  }
+
+                  imageSelectorContext.outputSizingMode = target.value as OutputSizingMode;
                 }}
               >
                 <option value="fixed_size">Fixed Size</option>
@@ -53,7 +58,12 @@ export default component$(() => {
                 class="input input-bordered w-full"
                 value={imageSelectorContext.outputSize.width}
                 onChange$={(e) => {
-                  const value = parseInt(e.target.value);
+                  const target = e.target as HTMLInputElement | null;
+                  if (!target) {
+                    return;
+                  }
+
+                  const value = parseInt(target.value);
                   if (!isNaN(value) && value > 0) {
                     imageSelectorContext.outputSize = { width: value, height: imageSelectorContext.outputSize.height };
                   }
@@ -69,7 +79,12 @@ export default component$(() => {
                 class="input input-bordered w-full"
                 value={imageSelectorContext.outputSize.height}
                 onChange$={(e) => {
-                  const value = parseInt(e.target.value);
+                  const target = e.target as HTMLInputElement | null;
+                  if (!target) {
+                    return;
+                  }
+
+                  const value = parseInt(target.value);
                   if (!isNaN(value) && value > 0) {
                     imageSelectorContext.outputSize = { width: imageSelectorContext.outputSize.width, height: value };
                   }
@@ -85,7 +100,12 @@ export default component$(() => {
               <select
                 class="select select-bordered"
                 onChange$={(e) => {
-                  imageSelectorContext.outputFormat = e.target.value as OutputFormat;
+                  const target = e.target as HTMLSelectElement | null;
+                  if (!target) {
+                    return;
+                  }
+
+                  imageSelectorContext.outputFormat = target.value as OutputFormat;
                 }}
               >
                 <option value="png">PNG</option>
@@ -104,7 +124,12 @@ export default component$(() => {
                 value={imageSelectorContext.downloadNameTemplate}
                 placeholder="Presize.io_{timestamp}"
                 onInput$={(e) => {
-                  imageSelectorContext.downloadNameTemplate = e.target.value;
+                  const target = e.target as HTMLInputElement | null;
+                  if (!target) {
+                    return;
+                  }
+
+                  imageSelectorContext.downloadNameTemplate = target.value;
                 }}
               />
             </div>


### PR DESCRIPTION
## Summary
- rename the export filename placeholder to {timestamp} and update the default template
- remove the newly added UI hint referring to #date and keep the rest of the zip name input unchanged
- roll back the in-progress image tagging changes introduced previously

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68eb2a0bc18483269d2548c60fbee6ed