### PR TITLE
Normalize image tag export formatting

### DIFF
--- a/apps/web/src/components/ImageItem.tsx
+++ b/apps/web/src/components/ImageItem.tsx
@@ -88,8 +88,8 @@ const ImageItem = (
     outputSizingMode,
     thumbnailScale,
     onDelete,
-    tag,
-    onTagChange,
+    caption,
+    onCaptionChange,
   }: {
     file: File;
     outputSize: Size;
@@ -97,8 +97,8 @@ const ImageItem = (
     outputSizingMode: OutputSizingMode;
     thumbnailScale: number;
     onDelete: () => void;
-    tag: string;
-    onTagChange: (value: string) => void;
+    caption: string;
+    onCaptionChange: (value: string) => void;
   },
   ref: Ref<AvatarEditor>,
 ) => {
@@ -259,15 +259,15 @@ const ImageItem = (
           />
         </div>
         <div className="form-control mt-2">
-          <label className="label py-0">
-            <span className="label-text text-xs">Tags</span>
+          <label className="label">
+            <span className="label-text text-xs">Caption</span>
           </label>
           <textarea
             className="textarea textarea-bordered textarea-xs w-full"
-            placeholder="Enter tags for this image"
-            value={tag}
+            placeholder="Caption will be stored in a text file alongside each image after download"
+            value={caption}
             onChange={(e) => {
-              onTagChange(e.target.value);
+              onCaptionChange(e.target.value);
             }}
           />
         </div>

--- a/apps/web/src/components/ImageItem.tsx
+++ b/apps/web/src/components/ImageItem.tsx
@@ -88,6 +88,8 @@ const ImageItem = (
     outputSizingMode,
     thumbnailScale,
     onDelete,
+    tag,
+    onTagChange,
   }: {
     file: File;
     outputSize: Size;
@@ -95,6 +97,8 @@ const ImageItem = (
     outputSizingMode: OutputSizingMode;
     thumbnailScale: number;
     onDelete: () => void;
+    tag: string;
+    onTagChange: (value: string) => void;
   },
   ref: Ref<AvatarEditor>,
 ) => {
@@ -251,6 +255,19 @@ const ImageItem = (
               } else {
                 setRotation(rot);
               }
+            }}
+          />
+        </div>
+        <div className="form-control mt-2">
+          <label className="label py-0">
+            <span className="label-text text-xs">Tags</span>
+          </label>
+          <textarea
+            className="textarea textarea-bordered textarea-xs w-full"
+            placeholder="Enter tags for this image"
+            value={tag}
+            onChange={(e) => {
+              onTagChange(e.target.value);
             }}
           />
         </div>

--- a/apps/web/src/components/ImageSelector.tsx
+++ b/apps/web/src/components/ImageSelector.tsx
@@ -14,7 +14,7 @@ type ImageFile = {
   id: string;
   file: File;
   editorRef?: AvatarEditor;
-  tag: string;
+  caption: string;
 };
 
 function TbPhotoPlus(props: SVGProps<SVGSVGElement>) {
@@ -68,7 +68,7 @@ function ImageSelectorImpl({
         ...acceptedFiles.map((file) => ({
           id: typeid().toString(),
           file,
-          tag: '',
+          caption: '',
         })),
         ...prev,
       ]);
@@ -89,7 +89,7 @@ function ImageSelectorImpl({
             id: file.id,
             file: file.file,
             blob: await getImageBlobFromEditor(file.editorRef, imageType, outputSizingMode),
-            tag: file.tag,
+            caption: file.caption,
           });
         }
       }
@@ -182,14 +182,14 @@ function ImageSelectorImpl({
           onDelete={() => {
             setFiles((prev) => prev.filter((f) => f.id !== file.id));
           }}
-          tag={file.tag}
-          onTagChange={(value) => {
+          caption={file.caption}
+          onCaptionChange={(value) => {
             setFiles((prev) =>
               prev.map((f) =>
                 f.id === file.id
                   ? {
                       ...f,
-                      tag: value,
+                      caption: value,
                     }
                   : f,
               ),

--- a/apps/web/src/components/ImageSelector.tsx
+++ b/apps/web/src/components/ImageSelector.tsx
@@ -14,6 +14,7 @@ type ImageFile = {
   id: string;
   file: File;
   editorRef?: AvatarEditor;
+  tag: string;
 };
 
 function TbPhotoPlus(props: SVGProps<SVGSVGElement>) {
@@ -67,6 +68,7 @@ function ImageSelectorImpl({
         ...acceptedFiles.map((file) => ({
           id: typeid().toString(),
           file,
+          tag: '',
         })),
         ...prev,
       ]);
@@ -87,6 +89,7 @@ function ImageSelectorImpl({
             id: file.id,
             file: file.file,
             blob: await getImageBlobFromEditor(file.editorRef, imageType, outputSizingMode),
+            tag: file.tag,
           });
         }
       }
@@ -178,6 +181,19 @@ function ImageSelectorImpl({
           thumbnailScale={thumbnailScale}
           onDelete={() => {
             setFiles((prev) => prev.filter((f) => f.id !== file.id));
+          }}
+          tag={file.tag}
+          onTagChange={(value) => {
+            setFiles((prev) =>
+              prev.map((f) =>
+                f.id === file.id
+                  ? {
+                      ...f,
+                      tag: value,
+                    }
+                  : f,
+              ),
+            );
           }}
         />
       ))}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -7,7 +7,7 @@ export type ProcessedImage = {
   id: string;
   file: File;
   blob: Blob;
-  tag?: string;
+  caption?: string;
 };
 
 export type Size = {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -7,6 +7,7 @@ export type ProcessedImage = {
   id: string;
   file: File;
   blob: Blob;
+  tag?: string;
 };
 
 export type Size = {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -163,6 +163,12 @@ export default component$(() => {
 
                   const newFileName = fileName.replace(/\.[^.]+$/, '') + `.${imageSelectorContext.outputFormat}`;
                   zip.file(newFileName, result.blob);
+                  if (result.tag && result.tag.trim().length > 0) {
+                    const textFileName = newFileName.replace(/\.[^.]+$/, '.txt');
+                    const normalizedTag = result.tag.replace(/\r\n/g, '\n').trim();
+                    const tagContent = normalizedTag.endsWith('\n') ? normalizedTag : normalizedTag + '\n';
+                    zip.file(textFileName, tagContent);
+                  }
                 }
 
                 const zipBlob = await zip.generateAsync({ type: 'blob' });

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -163,11 +163,13 @@ export default component$(() => {
 
                   const newFileName = fileName.replace(/\.[^.]+$/, '') + `.${imageSelectorContext.outputFormat}`;
                   zip.file(newFileName, result.blob);
-                  if (result.tag && result.tag.trim().length > 0) {
+                  if (result.caption && result.caption.trim().length > 0) {
                     const textFileName = newFileName.replace(/\.[^.]+$/, '.txt');
-                    const normalizedTag = result.tag.replace(/\r\n/g, '\n').trim();
-                    const tagContent = normalizedTag.endsWith('\n') ? normalizedTag : normalizedTag + '\n';
-                    zip.file(textFileName, tagContent);
+                    const normalizedCaption = result.caption.replace(/\r\n/g, '\n').trim();
+                    const captionContent = normalizedCaption.endsWith('\n')
+                      ? normalizedCaption
+                      : normalizedCaption + '\n';
+                    zip.file(textFileName, captionContent);
                   }
                 }
 


### PR DESCRIPTION
## Summary
- allow each selected image to store freeform tag text in the editor UI
- propagate the stored tags through processing so download bundles can include them
- attach .txt files containing the provided tags alongside each tagged image in the generated zip
- normalize exported tag text to use Unix newlines and end with a newline so training pipelines read them consistently

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_e_68eb41bb87c8832692fa389ef5b95c85